### PR TITLE
chore/switch nixos unstable small

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
     hooks:
       - id: actionlint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.12
     hooks:
       - id: ruff-format

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777236726,
-        "narHash": "sha256-ZTYDofOM3/PJhRF1EuBh6uibm+DmkhU7Wor6mMN7YTc=",
+        "lastModified": 1777434174,
+        "narHash": "sha256-KwTyQ5g2qDhWIs/O6vH8HeF8n4JCzZIT/VYE7nYnukQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e82d4a4ecd18363aa2054cbaa3e32e4134c3dbf4",
+        "rev": "d3b4e4b1bd59aedd3d4eb0a8df7162edb6da4607",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixos-unstable-small": {
       "locked": {
-        "lastModified": 1777230411,
-        "narHash": "sha256-HoSYm/rBAqKdqBsR3I4ygbuNQYVDzJ/1uKYqogYILm4=",
+        "lastModified": 1777368937,
+        "narHash": "sha256-aQ5pxj90ew4H2bSbupwmdJdv/jcIDn/jNcp/P+U3ccc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd38dbbe0f9c532e52efb75490e90e757e7b30d0",
+        "rev": "170bede2c6f335abfc2ff094addceea0ff7f40d2",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1777270315,
+        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1777236726,
+        "narHash": "sha256-ZTYDofOM3/PJhRF1EuBh6uibm+DmkhU7Wor6mMN7YTc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "e82d4a4ecd18363aa2054cbaa3e32e4134c3dbf4",
         "type": "github"
       },
       "original": {
@@ -59,6 +59,22 @@
         "type": "github"
       }
     },
+    "nixos-unstable-small": {
+      "locked": {
+        "lastModified": 1777230411,
+        "narHash": "sha256-HoSYm/rBAqKdqBsR3I4ygbuNQYVDzJ/1uKYqogYILm4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd38dbbe0f9c532e52efb75490e90e757e7b30d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1749619289,
@@ -77,11 +93,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -96,6 +112,7 @@
         "home-manager": "home-manager",
         "nil": "nil",
         "nix-darwin": "nix-darwin",
+        "nixos-unstable-small": "nixos-unstable-small",
         "nixpkgs": "nixpkgs_2",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Used as a pkg overlays where nixpkgs-unstable remains broken for long periods
+    # hosts/shared/software/default.nix(direnv)
+    nixos-unstable-small.url = "github:NixOS/nixpkgs/nixos-unstable-small";
     nix-darwin.url = "github:LnL7/nix-darwin/master";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
     home-manager.url = "github:nix-community/home-manager";
@@ -16,6 +19,7 @@
     nix-darwin,
     home-manager,
     nixpkgs,
+    nixos-unstable-small,
     systems,
     nil,
     ...

--- a/hosts/shared/darwin.nix
+++ b/hosts/shared/darwin.nix
@@ -4,7 +4,7 @@
   mainUser,
   ...
 }: let
-  system = pkgs.stdenv.hostPlatform.system;
+  inherit (pkgs.stdenv.hostPlatform) system;
 in {
   nixpkgs.hostPlatform = "aarch64-darwin";
   system.stateVersion = 5;

--- a/hosts/shared/software/default.nix
+++ b/hosts/shared/software/default.nix
@@ -28,6 +28,8 @@ in {
     # Disable the embedded ruby and python3 interpreters
     withRuby = false;
     withPython3 = false;
+    # Don't overwrite ~/.config/nvim/init.lua
+    sideloadInitLua = true;
   };
 
   # TODO: Remove this overlay configuration once direnv tests are passing in nixpkgs-unstable

--- a/hosts/shared/software/default.nix
+++ b/hosts/shared/software/default.nix
@@ -1,4 +1,10 @@
-{...}: {
+{
+  pkgs,
+  flake-inputs,
+  ...
+}: let
+  inherit (pkgs.stdenv.hostPlatform) system;
+in {
   imports = [
     ./atuin.nix
     ./btop.nix
@@ -24,9 +30,17 @@
     withPython3 = false;
   };
 
+  # TODO: Remove this overlay configuration once direnv tests are passing in nixpkgs-unstable
   programs.direnv = {
     enable = true;
-    nix-direnv.enable = true;
+    config = {
+      warn_timeout = "10m";
+    };
+    package = flake-inputs.nixos-unstable-small.legacyPackages.${system}.direnv;
+    nix-direnv = {
+      enable = true;
+      package = flake-inputs.nixos-unstable-small.legacyPackages.${system}.nix-direnv;
+    };
     enableZshIntegration = true;
   };
 


### PR DESCRIPTION
update flake
update pre-commit hooks
disable hm overwriting neovim init.lua
fix deprecated syntax for declaring hostPlatform