### PR TITLE
🐛 bugfix(tools): use oxalica Rust nixpkgs overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,7 +83,28 @@
         "nil": "nil",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
         "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779160702,
+        "narHash": "sha256-frUihZLlBLdcFN95mq5QiQmxF2M16nxtmw1GH4rhZmg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8cd592658d4448c57326aaa819e1c2f91086eb40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,11 @@
     systems.url = "github:nix-systems/default";
     nil.url = "github:oxalica/nil";
     nil.inputs.nixpkgs.follows = "nixpkgs";
+    # nixpkgs Rust lags behind the upstream stable versions
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs @ {
@@ -18,6 +23,7 @@
     home-manager,
     nixpkgs,
     systems,
+    rust-overlay,
     nil,
     ...
   }: let

--- a/hosts/shared/software/pkgs.nix
+++ b/hosts/shared/software/pkgs.nix
@@ -2,6 +2,7 @@
   pkgs,
   config,
   lib,
+  flake-inputs,
   ...
 }: let
   # Package shell scripts
@@ -42,6 +43,7 @@
       runHook postInstall
     '';
   };
+  rust-overlay-pkgs = pkgs.extend flake-inputs.rust-overlay.overlays.default;
   cfg = config.zshConfig;
 in {
   config = {
@@ -52,7 +54,6 @@ in {
           bat
           bat-extras.batman
           bfs
-          cargo
           cmake
           delta
           fd
@@ -75,8 +76,7 @@ in {
           pinentry-tty
           prek
           ripgrep
-          rustc
-          rustfmt
+          rust-overlay-pkgs.rust-bin.stable.latest.default
           shfmt
           tldr
           tree-sitter


### PR DESCRIPTION
Zed is using a macro not supported in 1.94.0