### PR TITLE
🐛 bugfix(tools): Fix git-lfs

### DIFF
--- a/hosts/shared/software/git.nix
+++ b/hosts/shared/software/git.nix
@@ -104,14 +104,6 @@ in {
           autoSetupRemove = true;
           followTags = true;
         };
-        filter = {
-          lfs = {
-            clean = "git-lfs clean -- %f";
-            smudge = "git-lfs smudge -- %f";
-            process = "git-lfs filter-process";
-            required = true;
-          };
-        };
       };
     };
   };

--- a/hosts/shared/software/pkgs.nix
+++ b/hosts/shared/software/pkgs.nix
@@ -96,7 +96,6 @@ in {
           pkgs.ansible-lint
           pkgs.awscli2
           pkgs.eks-node-viewer
-          pkgs.git-lfs
           pkgs.go
           pkgs.krew
           pkgs.kubecolor


### PR DESCRIPTION
Fixes:

```bash
┃        error: The option
`home-manager.users.michaelbeasley.programs.git.iniContent.filter.lfs.clean'
has conflicting definition values:
┃        - In
`/nix/store/icp6jizv472afzbd9i5b4gxp1y6rclcw-source/modules/programs/git.nix':
"/nix/store/k4xn1n4xfvjjjf6rn6k1drcs88dhvnv9-git-lfs-3.7.1/bin/git-lfs
clean -- %f"
┃        - In
`/nix/store/icp6jizv472afzbd9i5b4gxp1y6rclcw-source/modules/programs/git.nix':
"git-lfs clean -- %f"
┃        Use `lib.mkForce value` or `lib.mkDefault value` to change the
priority on any of these definitions.
```